### PR TITLE
Changed `position` property to `fixed` instead of `relative`

### DIFF
--- a/src/library/components/dialog/style.scss
+++ b/src/library/components/dialog/style.scss
@@ -10,7 +10,7 @@
   align-items: center;
 
   dialog, .dialog {
-    position: relative;
+    position: fixed;
   }
 }
 


### PR DESCRIPTION
This fix will center a given modal on the viewport that utilizes this library instead at the top of a given page